### PR TITLE
setup.sh: remove the bash hack

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,9 +7,6 @@ P=$PWD
 
 
 fixups() {
-	cd $P/workspace/layers/poky
-	# if /bin/sh is symlinked to other than bash
-	ls -l /bin/sh | grep -q bash || sed -i -e 's:/bin/sh:/bin/bash:g' bitbake/lib/bb/build.py
 	cd $P
 	# Apply patches
 	for LAYER in $(ls -1 $P/patches); do


### PR DESCRIPTION
Refer to the bitbake user manual:
https://www.yoctoproject.org/docs/2.7/bitbake-user-manual/bitbake-user-manual.html#shell-functions
---
When you create these types of functions in your recipe or class files,
you need to follow the shell programming rules. The scripts are executed
by /bin/sh, which may not be a bash shell but might be something such as
dash. You should not use Bash-specific script (bashisms).
---

so we should not use the hack in bitbake and we should remove the
bashisms in the recipes in meta-stx.

fix zbsarashki/meta-stx#103

Signed-off-by: Jackie Huang <jackie.huang@windriver.com>