### PR TITLE
setup.sh: add support for building iso image

### DIFF
--- a/patches/poky/0001-image-live.bbclass-work-around-for-large-image-size.patch
+++ b/patches/poky/0001-image-live.bbclass-work-around-for-large-image-size.patch
@@ -1,0 +1,32 @@
+From badbce21b5709b1691a759fa3663c41bcc3eb273 Mon Sep 17 00:00:00 2001
+From: Jackie Huang <jackie.huang@windriver.com>
+Date: Fri, 20 Sep 2019 14:25:45 +0800
+Subject: [PATCH] image-live.bbclass: work around for large image size
+
+This should be removed once we reduce the image size to less than 4G.
+
+Signed-off-by: Jackie Huang <jackie.huang@windriver.com>
+---
+ meta/classes/image-live.bbclass | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/meta/classes/image-live.bbclass b/meta/classes/image-live.bbclass
+index 54058b3..bd607aa 100644
+--- a/meta/classes/image-live.bbclass
++++ b/meta/classes/image-live.bbclass
+@@ -229,9 +229,10 @@ build_hddimg() {
+ 		# exceeds 4GB, it is the single file's max size of FAT fs.
+ 		if [ -f ${HDDDIR}/rootfs.img ]; then
+ 			rootfs_img_size=`stat -c '%s' ${HDDDIR}/rootfs.img`
+-			max_size=`expr 4 \* 1024 \* 1024 \* 1024`
++			max_size=`expr 8 \* 1024 \* 1024 \* 1024`
+ 			if [ $rootfs_img_size -ge $max_size ]; then
+-				bberror "${HDDDIR}/rootfs.img rootfs size is greather than or equal to 4GB,"
++				bberror "${HDDDIR}/rootfs.img rootfs size is $rootfs_img_size,"
++				bberror "which is greather than or equal to 4GB($max_size),"
+ 				bberror "and this doesn't work on a FAT filesystem. You can either:"
+ 				bberror "1) Reduce the size of rootfs.img, or,"
+ 				bbfatal "2) Use wic, vmdk or vdi instead of hddimg\n"
+-- 
+2.7.4
+

--- a/setup.sh
+++ b/setup.sh
@@ -78,7 +78,8 @@ EOF
 
 	sed -i -e 's/^\(#MACHINE.*\"qemuarm\"\)/MACHINE \?= \"intel-corei7-64\"\n\1/g' conf/local.conf
 	echo 'PREFERRED_PROVIDER_virtual/kernel = "linux-yocto"' >> conf/local.conf
-	echo 'IMAGE_FSTYPES = " tar.bz2"' >> conf/local.conf
+	echo 'IMAGE_FSTYPES = " tar.bz2 live"' >> conf/local.conf
+	echo 'LABELS_LIVE = "install"' >> conf/local.conf
 	echo 'EXTRA_IMAGE_FEATURES ?= "debug-tweaks"'  >> conf/local.conf
 	echo 'EXTRA_IMAGE_FEATURES += "tools-sdk"' >> conf/local.conf
 	echo 'EXTRA_IMAGE_FEATURES += "tools-debug"' >> conf/local.conf


### PR DESCRIPTION
This is for creating a ISO with an automatic installer
aligned with stx 3.0 AIO simplex scenario.

The following changes are included:
- Add a patch for poky layer to workaround large image issue.
- Add live into IMAGE_FSTYPES
- Set LABELS_LIVE to "install" so that the boot menu only
  includes the ones for installer.

fix zbsarashki/meta-stx#102

Signed-off-by: Jackie Huang <jackie.huang@windriver.com>